### PR TITLE
Commenting out lockFocus that cause crashes.

### DIFF
--- a/Classes/GitDiff.mm
+++ b/Classes/GitDiff.mm
@@ -300,7 +300,8 @@ static bool exists( const _M &map, const _K &key ) {
             diffs->lines = [[[self sourceTextView].string componentsSeparatedByString:@"\n"] count];
         }
 
-        [self lockFocus];
+// This lockFocus may cause crashes.
+//        [self lockFocus];
 
         for ( const auto &added : diffs->added ) {
             unsigned long line = added.first;
@@ -319,7 +320,7 @@ static bool exists( const _M &map, const _K &key ) {
             }
         }
 
-        [self unlockFocus];
+//        [self unlockFocus];
     }
 }
 


### PR DESCRIPTION
I haven't found a solution for it. But commenting out lockFocus at least avoid a systematic crash of some of my projects.
