### PR TITLE
Fixed color wells not loading correctly in color preferences window

### DIFF
--- a/Classes/GitDiffColorsWindowController.m
+++ b/Classes/GitDiffColorsWindowController.m
@@ -32,6 +32,9 @@ NSString *const GitDiffChangedColorKey  = @"GitDiffChangedColor";
 @implementation GitDiffColorsWindowController
 
 - (instancetype)initWithPluginBundle:(NSBundle *)bundle {
+    
+    
+    
     NSString *nibPath = [bundle pathForResource:@"GitDiff" ofType:@"nib"];
     if (!nibPath) {
         NSLog( @"GitDiff Plugin: Could not load colors interface." );
@@ -43,10 +46,12 @@ NSString *const GitDiffChangedColorKey  = @"GitDiffChangedColor";
         NSString *pluginDefaultsPath = [bundle pathForResource:@"Defaults" ofType:@"plist"];
         _pluginDefaults = [NSDictionary dictionaryWithContentsOfFile:pluginDefaultsPath];
         _userDefaults   = [NSUserDefaults standardUserDefaults];
-        
-        [self loadColors];
     }
     return self;
+}
+
+- (void)awakeFromNib {
+    [self loadColors];
 }
 
 


### PR DESCRIPTION
You're fast! Found a tiny bug where the color wells aren't initialized properly.
Thanks for building this plugin, I started writing [one](https://github.com/allewun/Xcode-GitGutter) myself but didn't have enough experience with OS X development.
