### PR TITLE
Fix rendering bug when hovering change

### DIFF
--- a/Classes/GitDiff.mm
+++ b/Classes/GitDiff.mm
@@ -45,8 +45,6 @@ static GitDiff *gitDiffPlugin;
 		[gitDiffPlugin insertMenuItems];
         
 		gitDiffPlugin.popover = [[NSTextView alloc] initWithFrame:NSZeroRect];
-		gitDiffPlugin.popover.wantsLayer = YES;
-		gitDiffPlugin.popover.layer.cornerRadius = 6.0;
 
 		gitDiffPlugin.sourceDocClass = NSClassFromString(@"IDESourceCodeDocument");
 		[self swizzleClass:[NSDocument class]


### PR DESCRIPTION
![screen shot 2014-09-22 at 08 12 33](https://cloud.githubusercontent.com/assets/57446/4352181/8124a7fc-421f-11e4-8351-91fec04d6851.PNG)

There is a bug in Xcode 6 under OS X 10.10 when you hover a change in the sidebar.
This is fixed by removing _.wantsLayer_ on the popover.
I also removed the corner radius as it no longer makes sense for it to be there.

This is how it looks like without the .wantsLayer property set to YES.

![screen shot 2014-09-22 at 08 14 30](https://cloud.githubusercontent.com/assets/57446/4352191/c534146e-421f-11e4-9fdb-a640309c6e46.PNG)
