### PR TITLE
Silence as build warning, for size mismatch

### DIFF
--- a/DiffMatchPatch/DiffMatchPatch.m
+++ b/DiffMatchPatch/DiffMatchPatch.m
@@ -121,7 +121,7 @@ NSMutableArray *diff_diffsBetweenTextsWithProperties(NSString *text1, NSString *
 	
 	
 	// Test if the deadline is zero or has already passed
-	if(fabsf(properties.deadline) < 0.00000001) {
+	if(fabs(properties.deadline) < 0.00000001) {
 		properties.deadline = [[NSDate distantFuture] timeIntervalSinceReferenceDate];
 	} else {
 		NSTimeInterval currentTime = [NSDate timeIntervalSinceReferenceDate];


### PR DESCRIPTION
`deadline` is an NSTimerInterval which is a typedef on double. Therefore `fabs` should be used.