### PR TITLE
Add support for disabling the gutter popover view

### DIFF
--- a/Classes/GitDiff.mm
+++ b/Classes/GitDiff.mm
@@ -397,7 +397,9 @@ static void handler( int sig ) {
     NSTextView *popover = gitDiffPlugin.popover;
     popover.backgroundColor = gitDiffPlugin.colorsWindowController.popoverColor;
 
-    if ( !annotation && p0.x < self.sidebarWidth ) {
+    BOOL displayAnnotation = [[NSUserDefaults standardUserDefaults] boolForKey:@"GitDiffDisplayAnnotation"];
+
+    if ( displayAnnotation && !annotation && p0.x < self.sidebarWidth ) {
         GitFileDiffs *diffs = [self gitDiffs];
         NSUInteger line = [self lineNumberForPoint:p0];
 

--- a/Defaults.plist
+++ b/Defaults.plist
@@ -12,5 +12,7 @@
 	<string>1 0.914 0.662 1</string>
 	<key>GitDiffChangedColor</key>
 	<string>0.129 0.313 1 1</string>
+	<key>GitDiffDisplayAnnotation</key>
+	<true/>
 </dict>
 </plist>

--- a/en.lproj/GitDiff.xib
+++ b/en.lproj/GitDiff.xib
@@ -20,14 +20,14 @@
         <window title="GitDiff Configuration" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="308" height="279"/>
+            <rect key="contentRect" x="196" y="240" width="308" height="300"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="878"/>
             <view key="contentView" id="EiT-Mj-1SZ">
-                <rect key="frame" x="0.0" y="5" width="308" height="279"/>
+                <rect key="frame" x="0.0" y="6" width="308" height="300"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <box autoresizesSubviews="NO" title="Colors" borderType="line" id="Ivu-Kd-Qvr">
-                        <rect key="frame" x="17" y="127" width="274" height="132"/>
+                        <rect key="frame" x="17" y="148" width="274" height="132"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <view key="contentView">
                             <rect key="frame" x="1" y="1" width="272" height="116"/>
@@ -147,7 +147,7 @@ Gw
                         </textFieldCell>
                     </textField>
                     <popUpButton verticalHuggingPriority="750" id="nV0-ew-buy">
-                        <rect key="frame" x="129" y="88" width="145" height="26"/>
+                        <rect key="frame" x="129" y="109" width="145" height="26"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="6ZP-Tm-stV">
                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -175,7 +175,7 @@ Gw
                         <rect key="frame" x="131" y="20" width="157" height="38"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        <size key="cellSize" width="124" height="18"/>
+                        <size key="cellSize" width="121" height="18"/>
                         <size key="intercellSpacing" width="4" height="2"/>
                         <buttonCell key="prototype" type="radio" title="Radio" imagePosition="left" alignment="left" inset="2" id="ATZ-N2-spP">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -198,7 +198,7 @@ Gw
                         </connections>
                     </matrix>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="aVx-1I-iMp">
-                        <rect key="frame" x="34" y="93" width="91" height="17"/>
+                        <rect key="frame" x="34" y="114" width="91" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Gutter marks:" id="FKM-2f-yPZ">
                             <font key="font" metaFont="system"/>
@@ -206,9 +206,20 @@ Gw
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
+                    <button id="IDW-WA-DHG">
+                        <rect key="frame" x="129" y="82" width="113" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Show Popover" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="6fu-h1-g85">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <binding destination="Y8c-8q-f8n" name="value" keyPath="values.GitDiffDisplayAnnotation" id="VBs-oP-VGp"/>
+                        </connections>
+                    </button>
                 </subviews>
             </view>
-            <point key="canvasLocation" x="279" y="361.5"/>
+            <point key="canvasLocation" x="279" y="372"/>
         </window>
         <userDefaultsController representsSharedInstance="YES" id="Y8c-8q-f8n"/>
     </objects>


### PR DESCRIPTION
I personally find the popover really distracting when I mouse over it by mistake.

This is a quick patch to make showing / hiding it a configurable option (it defaults to displaying it, to not break existing usage).

