### PR TITLE
Hook "mouseExited:" to dismiss popover.

### DIFF
--- a/Classes/GitDiff.mm
+++ b/Classes/GitDiff.mm
@@ -86,6 +86,9 @@ static GitDiff *gitDiffPlugin;
             [self swizzleClass:aClass
                       exchange:@selector(annotationAtSidebarPoint:)
                           with:@selector(gitdiff_annotationAtSidebarPoint:)];
+            [self swizzleClass:aClass
+                      exchange:@selector(mouseExited:)
+                          with:@selector(gitdiff_mouseExited:)];
 
             aClass = NSClassFromString(@"DVTMarkedScroller");
             [self swizzleClass:aClass
@@ -487,6 +490,14 @@ static void handler( int sig ) {
     }
 
     return annotation;
+}
+
+- (void)gitdiff_mouseExited:(id)arg {
+    [self gitdiff_mouseExited:arg];
+    if ( [gitDiffPlugin.popover superview] ) {
+        [gitDiffPlugin.popover removeFromSuperview];
+        [gitDiffPlugin.colorsWindowController.undoButton removeFromSuperview];
+    }
 }
 
 - (void)showUndo


### PR DESCRIPTION
The "undo popover" kept showing even after mouse moved out of the "line number area" from the left edge, like this:
![popover_not_dismissing](https://cloud.githubusercontent.com/assets/788863/12837347/3fcbaec4-cc05-11e5-9f01-aa7d28ff8227.png)

Maybe it's just me that puts the iOS simulator to the left side of Xcode. But since the popover dismisses when move mouse out from the right edge, I think it should also dismiss when move mouse out from the left edge.